### PR TITLE
Fixe extends schema lookups

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -877,9 +877,6 @@ check_extends_array(Value, Extends, State) ->
 check_ref(Value, Ref, State) ->
   Path = apply_reference_symbols(Ref),
   case get_schema(parse_relative_ref(Path), State) of
-    {ok, []} ->
-      %%FIXME: wat? this is root pointer ref right?
-      State;
     {error, unable_to_fetch_schema} ->
       State;
     {ok, [{_, _, _, {Schema}}]} ->

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -882,6 +882,8 @@ check_ref(Value, Ref, State) ->
       State;
     {error, unable_to_fetch_schema} ->
       State;
+    {ok, [{_, _, _, {Schema}}]} ->
+      check_value(Value, Schema, State);
     {ok, {Schema}} ->
       check_value(Value, Schema, State)
   end.
@@ -925,8 +927,22 @@ get_schema({local, [First | _] = Parts}, _State) ->
           {ok, get_schema_path(Parts, Schema)}
       end
   end;
-get_schema({local, Schema}, State) ->
-  get_schema({local, [Schema]}, State).
+get_schema({local, SchemaName}, _State) ->
+  case jesse_database:get_all() of
+    [] ->
+      {error, {schema_not_found, SchemaName}};
+    Schemas ->
+      %% find schema id in cached schemas
+      PredFun = fun({Name, _, _, _}) ->
+                    Name =:= binary_to_list(SchemaName)
+                end,
+      case lists:filter(PredFun, Schemas) of
+        [] ->
+          {error, {schema_not_found, SchemaName}};
+        Schema ->
+          {ok, Schema}
+      end
+  end.
 
 get_schema_path([], Schema) ->
   Schema;


### PR DESCRIPTION
Using extends like below would never work and it would hit the `{ok, []}` case branch, making extends silently fail with nothing being validated from the extend schema.

``` json
{
"extends": "other_schema"
}
```
